### PR TITLE
Fix slf4j adapter

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,5 +7,5 @@
                  [org.clojure/tools.logging "0.2.6"]
                  [clj-logging-config "1.9.10"]
                  [org.clojars.pjlegato/clansi "1.3.0"]
-                 [org.slf4j/slf4j-log4j12 "1.7.7"]
+                 [org.slf4j/log4j-over-slf4j "1.7.18"]
                  ])


### PR DESCRIPTION
Currently, `onelog` depends on `slf4j-log4j` lib. However, according to [slf4j docs](http://www.slf4j.org/legacy.html#log4jRecursion): 

> The presence of `slf4j-log4j12.jar`, that is the log4j binding for SLF4J, will force all SLF4J calls to be delegated to `log4j`. The presence of `log4j-over-slf4j.jar` will in turn delegate all log4j API calls to their SLF4J equivalents. 

Since `clj-logging-config` uses `log4j`, it seems that `onelog` should depend on `log4j-over-slf4j.jar`, instead of `slf4j-log4j`. In this way, all `clj-logging-config` logs will be routed to SLF4J. 