### PR TITLE
Fix `ns` declaration in onelog.core to prevent errors in clojure.core versions that use spec to validate forms

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,6 +8,6 @@
                  [clj-logging-config "1.9.10" :exclusions [log4j]]
                  [org.clojars.pjlegato/clansi "1.3.0"]
                  [org.slf4j/slf4j-log4j12 "1.7.7"]
-                 [io.aviso/pretty "0.1.12"] ;; Pretty printer / exception formatter
+                 [io.aviso/pretty "0.1.30"] ;; Pretty printer / exception formatter
                  ])
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject onelog "0.5.1-SNAPSHOT"
+(defproject onelog "0.5.1"
   :description "Batteries-included logging for Clojure"
   :url "https://github.com.com/pjlegato/onelog"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject onelog "0.5.0"
+(defproject onelog "0.5.1-SNAPSHOT"
   :description "Batteries-included logging for Clojure"
   :url "https://github.com.com/pjlegato/onelog"
   :license {:name "Eclipse Public License"

--- a/src/onelog/core.clj
+++ b/src/onelog/core.clj
@@ -12,9 +12,8 @@ TODO: Add profiling methods (i.e. run a function and log how long it took)
    [clojure.tools.logging :as log]
    [io.aviso.exception :refer [write-exception format-exception]]
    [clj-logging-config.log4j :as log-config]
-   [clansi.core :as ansi]
-   )
-  (:import (org.apache.log4j DailyRollingFileAppender EnhancedPatternLayout FileAppender)))
+   [clansi.core :as ansi])
+  (:import [org.apache.log4j DailyRollingFileAppender EnhancedPatternLayout FileAppender]))
 
 
 (defn color


### PR DESCRIPTION
Requiring this library, specifically required in`ring.middleware.logger`, causes exceptions in current Clojure versions (`1.9.0-alpha12`) due to the `ns` form not passing `spec` validations.
